### PR TITLE
Allow using credential.id for username/password

### DIFF
--- a/scripts/scripts/credentials.groovy
+++ b/scripts/scripts/credentials.groovy
@@ -58,6 +58,6 @@ private user(credentials, key) {
             def constructor = Class.forName("com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials").getConstructor(CredentialsScope.class, String.class, String.class, String.class, String.class, String.class)
             return constructor.newInstance(CredentialsScope.GLOBAL, credentials.id, credentials.description, credentials.storageAccountName, credentials.storageKey, credentials.endpointUrl)
         default:
-            return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, key, credentials.description, credentials.username, credentials.password)
+            return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentials.id ?: key, credentials.description, credentials.username, credentials.password)
     }
 }

--- a/src/test/groovy/scripts/CredentialsTest.groovy
+++ b/src/test/groovy/scripts/CredentialsTest.groovy
@@ -38,6 +38,9 @@ class CredentialsTest extends StartupTest {
         assertThat(usernamePasswordCredentials[0].getPassword() as String, equalTo("somes3cret"))
         assertThat(usernamePasswordCredentials[1].getUsername() as String, equalTo("cloud"))
         assertThat(usernamePasswordCredentials[1].getPassword() as String, equalTo("cl0ud"))
+        assertThat(usernamePasswordCredentials[2].getId() as String, equalTo("somewhere-cool"))
+        assertThat(usernamePasswordCredentials[2].getUsername() as String, equalTo("somewhere"))
+        assertThat(usernamePasswordCredentials[2].getPassword() as String, equalTo("somes3cret"))
 
         def basicSSHUserPrivateKey = getCredentialsOfType("BasicSSHUserPrivateKey")
         assertThat(basicSSHUserPrivateKey[0].getUsername() as String, equalTo("ssh"))

--- a/src/test/resources/scripts/CredentialsTest/jenkins.config
+++ b/src/test/resources/scripts/CredentialsTest/jenkins.config
@@ -1,6 +1,7 @@
 credentials {
     repository=['username':'repository', 'password':'ENC(AAAADKGPigC2vDGp7Btx8Z+KyEmJUp8DobiaJ9QoaoxS0nWk7feTvo0O)', 'description':'repository credentials']
     cloud=['username':'cloud', 'password':'ENC(AAAADBG5Hw+6UzWIbJQogBA7PjSUDZAF4TGqfwzkuL/CbbTn8w==)', 'description':'cloud credentials']
+    somewhereCool=[id: 'somewhere-cool', 'username':'somewhere', 'password':'ENC(AAAADKGPigC2vDGp7Btx8Z+KyEmJUp8DobiaJ9QoaoxS0nWk7feTvo0O)', 'description':'somewhere-cool credentials']
     ssh=['username':'ssh', 'password':'ENC(AAAADDp9istmVU5kLc8CDFArqEAWel5iQmveVw/ro3bgwY1QLQ==)', 'description':'node credentials', 'type': 'SSH', 'privateKeyFile':'.ssh/id_rsa']
     vault=['description': 'vault credentials', 'key':'super/secret', 'usernameKey': "username", 'passwordKey': "password", 'type': 'HashicorpVault']
     saucelabs=['description': 'SauceLabs credentials', 'username': 'slUser', 'apiKey': 'slApiKey', 'type': 'SauceLabs']


### PR DESCRIPTION
Allow using credential.id for username/password

Using the groovy key prevents certain IDs from being used such as:
`an id` or `an-id`

This is problematic for us as some IDs already in use have dashes in them and changing them is a PITA,
Allowing passing an ID is more flexible and already in use for some of the credential types

I'm happy to either change all of the creds to accept key or credential.id
Or just the id, was just wary of making a breaking change

An example of the error is:
```
[owasp-db-login] is a constant expression, but it should be a variable expression at line: 43 column: 21. File: script15327186420141162630171.groovy @ line 43, column 21.
       'owasp-db-login'=['username':'owasp_administrator', 'password':'****', 'description':'OWASP DB creds']
```
https://stackoverflow.com/a/8813678/4951015
